### PR TITLE
Incorrect calculation of width and height with adaptivity in ios safari

### DIFF
--- a/jquery.maphilight.js
+++ b/jquery.maphilight.js
@@ -254,8 +254,8 @@
 				backgroundSize:'contain',
 				position:'relative',
 				padding:0,
-				width:this.width,
-				height:this.height
+				width:$(this).width(),
+				height:$(this).height()
 				});
 			if(options.wrapClass) {
 				if(options.wrapClass === true) {


### PR DESCRIPTION
In the original version on ios safari, the width and height values ​​are those that are set in the 'width' and 'height' attributes. To calculate real, current values ​​works through the appropriate jquery methods